### PR TITLE
chore(deps): bump cryptography 46.0.5 → 46.0.6 (combines PR #118)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+asn1crypto==1.5.1
+certifi==2026.2.25
+cffi==2.0.0
+cryptography==46.0.6
+defusedxml==0.7.1
+eight==1.0.1
+future==1.0.0
+lxml==6.0.2
+pyasn1==0.6.3
+pyOpenSSL==26.0.0
+pycparser==3.0
+signxml==4.4.0
+six==1.17.0


### PR DESCRIPTION
Combines conflicting PR #118 into a clean branch on top of current master.

**Changes:**
- `cryptography` 46.0.5 → 46.0.6 (security patch)

Closes #118